### PR TITLE
グループ編集機能のうちupdate機能の修正

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -22,7 +22,7 @@ class GroupsController < ApplicationController
   end
 
   def update
-    if Group.update(group_params)
+    if @group.update(group_params)
       redirect_to group_messages_path(@group), notice: "グループを編集しました"
     else
       render :edit


### PR DESCRIPTION
##What
チャットグループ編集時に毎回グループid=1が編集されてしまう不具合を解消

##Why
どのグループを選択して編集しても想定外のグループの編集をしてしてしまうため。