### PR TITLE
脆弱性ファイルへの対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'jbuilder', '~> 2.5'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+gem 'sprockets', '~>3.7.2'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -277,6 +277,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
+  sprockets (~> 3.7.2)
   tzinfo-data
   uglifier (>= 1.3.0)
   unicorn


### PR DESCRIPTION
##What
sprocketsを3.7.2にアップデート

##Why
sprocketsが3.7.1だと脆弱性が起きる可能性があったため3.7.2に変更。（3.7.1でもconfig.assets.compile = falseがデフォルトなので問題なかったが念のため）